### PR TITLE
Add langTag for /paginated request and response

### DIFF
--- a/src/client/epics/index.js
+++ b/src/client/epics/index.js
@@ -125,13 +125,15 @@ const fetchResultsEpic = (action$, state$) => action$.pipe(
   withLatestFrom(state$),
   mergeMap(([action, state]) => {
     const { perspectiveID, resultClass, facetClass, limit, optimize } = action
+    const langTag = state.options.currentLocale
     const params = stateToUrl({
       perspectiveID,
       facets: facetClass ? state[`${facetClass}Facets`].facets : null,
       facetClass,
       uri: action.uri ? action.uri : null,
       limit,
-      optimize
+      optimize,
+      langTag
     })
     const requestUrl = `${apiUrl}/faceted-search/${resultClass}/all`
     // https://rxjs-dev.firebaseapp.com/api/ajax/ajax
@@ -167,6 +169,7 @@ const fetchInstanceAnalysisEpic = (action$, state$) => action$.pipe(
   withLatestFrom(state$),
   mergeMap(([action, state]) => {
     const { resultClass, facetClass, fromID, toID, period, province } = action
+    const langTag = state.options.currentLocale
     const params = stateToUrl({
       facets: facetClass ? state[`${facetClass}Facets`].facets : null,
       facetClass,
@@ -174,7 +177,8 @@ const fetchInstanceAnalysisEpic = (action$, state$) => action$.pipe(
       fromID,
       toID,
       period,
-      province
+      province,
+      langTag
     })
     const requestUrl = `${apiUrl}/faceted-search/${resultClass}/all`
     // https://rxjs-dev.firebaseapp.com/api/ajax/ajax
@@ -271,10 +275,12 @@ const fetchByURIEpic = (action$, state$) => action$.pipe(
   withLatestFrom(state$),
   mergeMap(([action, state]) => {
     const { perspectiveID, resultClass, facetClass, uri } = action
+    const langTag = state.options.currentLocale
     const params = stateToUrl({
       perspectiveID,
       facets: facetClass == null ? null : state[`${facetClass}Facets`].facets,
-      facetClass
+      facetClass,
+      langTag
     })
     const requestUrl = `${apiUrl}/${resultClass}/page/${encodeURIComponent(uri)}`
     return ajax({
@@ -311,11 +317,13 @@ const fetchFacetEpic = (action$, state$) => action$.pipe(
     const facets = state[`${facetClass}Facets`].facets
     const facet = facets[facetID]
     const { sortBy = null, sortDirection = null } = facet
+    const langTag = state.options.currentLocale
     const params = stateToUrl({
       facets,
       sortBy,
       sortDirection,
-      constrainSelf
+      constrainSelf,
+      langTag
     })
     const requestUrl = `${apiUrl}/faceted-search/${action.facetClass}/facet/${facetID}`
     return ajax({
@@ -355,11 +363,13 @@ const fetchFacetConstrainSelfEpic = (action$, state$) => action$.pipe(
     const facets = state[`${facetClass}Facets`].facets
     const facet = facets[facetID]
     const { sortBy, sortDirection } = facet
+    const langTag = state.options.currentLocale
     const params = stateToUrl({
       facets: facets,
       sortBy: sortBy,
       sortDirection: sortDirection,
-      constrainSelf: true
+      constrainSelf: true,
+      langTag
     })
     const requestUrl = `${apiUrl}/faceted-search/${action.facetClass}/facet/${facetID}`
     return ajax({

--- a/src/client/epics/index.js
+++ b/src/client/epics/index.js
@@ -80,13 +80,15 @@ const fetchPaginatedResultsEpic = (action$, state$) => action$.pipe(
   mergeMap(([action, state]) => {
     const { resultClass, facetClass, sortBy } = action
     const { page, pagesize, sortDirection } = state[resultClass]
+    const langTag = state.options.currentLocale
     const params = stateToUrl({
       facets: state[`${facetClass}Facets`].facets,
       facetClass: null,
       page,
       pagesize,
       sortBy,
-      sortDirection
+      sortDirection,
+      langTag
     })
     const requestUrl = `${apiUrl}/faceted-search/${resultClass}/paginated`
     // https://rxjs-dev.firebaseapp.com/api/ajax/ajax

--- a/src/configs/sampo/search_perspectives/perspective1.json
+++ b/src/configs/sampo/search_perspectives/perspective1.json
@@ -11,6 +11,7 @@
     "facetClass": "frbroo:F1_Work",
     "frontPageImage": "main_page/works-452x262.jpg",
     "searchMode": "faceted-search",
+    "enableDynamicLanguageChange": false,
     "defaultActiveFacets": [
         "prefLabel"
     ],

--- a/src/configs/sampo/search_perspectives/perspective2.json
+++ b/src/configs/sampo/search_perspectives/perspective2.json
@@ -11,6 +11,7 @@
     "facetClass": "frbroo:F4_Manifestation_Singleton",
     "frontPageImage": "main_page/manuscripts-452x262.jpg",
     "searchMode": "faceted-search",
+    "enableDynamicLanguageChange": false,
     "defaultActiveFacets": [],
     "defaultTab": "table",
     "defaultInstancePageTab": "table",

--- a/src/configs/sampo/search_perspectives/perspective3.json
+++ b/src/configs/sampo/search_perspectives/perspective3.json
@@ -11,6 +11,7 @@
     "facetClass": "crm:E10_Transfer_of_Custody crm:E12_Production mmm-schema:ManuscriptActivity",
     "frontPageImage": "main_page/events-452x262.jpg",
     "searchMode": "faceted-search",
+    "enableDynamicLanguageChange": false,
     "defaultActiveFacets": [],
     "defaultTab": "table",
     "defaultInstancePageTab": "table",

--- a/src/configs/sampo/search_perspectives/perspective4.json
+++ b/src/configs/sampo/search_perspectives/perspective4.json
@@ -4,6 +4,7 @@
     "sparqlQueries": "federatedSearchSparqlQueries",
     "frontPageImage": "main_page/places-452x262.jpg",
     "searchMode": "federated-search",
+    "enableDynamicLanguageChange": false,
     "defaultActiveFacets": [
         "datasetSelector"
     ],

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -83,7 +83,7 @@ createBackendSearchConfig().then(backendSearchConfig => {
         sortDirection: body.sortDirection,
         constraints: body.constraints,
         resultFormat: 'json',
-        langTag: body.langTag
+        dynamicLangTag: body.langTag
       })
       res.json(data)
     } catch (error) {
@@ -109,7 +109,8 @@ createBackendSearchConfig().then(backendSearchConfig => {
         fromID: body.fromID,
         toID: body.toID,
         period: body.period,
-        province: body.province
+        province: body.province,
+        dynamicLangTag: body.langTag
       })
       if (resultFormat === 'csv') {
         res.writeHead(200, {
@@ -135,7 +136,8 @@ createBackendSearchConfig().then(backendSearchConfig => {
         resultClass: req.params.resultClass,
         facetClass: req.query.facetClass || null,
         constraints: req.query.constraints == null ? null : req.query.constraints,
-        resultFormat: resultFormat
+        resultFormat: resultFormat,
+        dynamicLangTag: req.body.langTag
       })
       if (resultFormat === 'csv') {
         res.writeHead(200, {
@@ -176,7 +178,8 @@ createBackendSearchConfig().then(backendSearchConfig => {
         uri: params.uri,
         facetClass: body.facetClass,
         constraints: body.constraints,
-        resultFormat: 'json'
+        resultFormat: 'json',
+        dynamicLangTag: body.langTag
       })
       res.json(data)
     } catch (error) {
@@ -195,7 +198,8 @@ createBackendSearchConfig().then(backendSearchConfig => {
         sortDirection: body.sortDirection,
         constraints: body.constraints,
         resultFormat: 'json',
-        constrainSelf: body.constrainSelf
+        constrainSelf: body.constrainSelf,
+        dynamicLangTag: body.langTag
       })
       res.json(data)
     } catch (error) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -82,7 +82,8 @@ createBackendSearchConfig().then(backendSearchConfig => {
         sortBy: body.sortBy,
         sortDirection: body.sortDirection,
         constraints: body.constraints,
-        resultFormat: 'json'
+        resultFormat: 'json',
+        langTag: body.langTag
       })
       res.json(data)
     } catch (error) {

--- a/src/server/openapi.yaml
+++ b/src/server/openapi.yaml
@@ -115,7 +115,12 @@ paths:
                     type: object
                   nullable: true
                   default: null
-                  example: null  
+                  example: null
+                langTag:
+                  type: string
+                  nullable: false
+                  default: en
+                  example: en  
       responses:
         '200':   
           description: All search results
@@ -246,7 +251,12 @@ paths:
                     default: null
                 constrainSelf:
                   type: boolean
-                  default: false           
+                  default: false    
+                langTag:
+                  type: string
+                  nullable: false
+                  default: en
+                  example: en       
       responses:
         '200':   
           description: Facet values
@@ -307,6 +317,11 @@ paths:
                       type: object
                     nullable: true
                     default: null
+                langTag:
+                  type: string
+                  nullable: false
+                  default: en
+                  example: en
       responses:
         '200':
           description: Information about a single resource

--- a/src/server/openapi.yaml
+++ b/src/server/openapi.yaml
@@ -60,7 +60,12 @@ paths:
                     type: object
                   nullable: true
                   default: null
-                  example: null  
+                  example: null 
+                langTag:
+                  type: string
+                  nullable: false
+                  default: en
+                  example: en
       responses:
         '200':   
           description: Paginated search results

--- a/src/server/sparql/FacetResults.js
+++ b/src/server/sparql/FacetResults.js
@@ -17,7 +17,8 @@ export const getPaginatedResults = ({
   constraints,
   sortBy,
   sortDirection,
-  resultFormat
+  resultFormat,
+  langTag,
 }) => {
   let q = facetResultSetQuery
   const perspectiveConfig = backendSearchConfig[resultClass]
@@ -26,7 +27,6 @@ export const getPaginatedResults = ({
     facets,
     facetClass,
     defaultConstraint = null,
-    langTag = null,
     langTagSecondary = null
   } = perspectiveConfig
   const resultClassConfig = perspectiveConfig.resultClasses[resultClass]

--- a/src/server/sparql/FacetResults.js
+++ b/src/server/sparql/FacetResults.js
@@ -18,7 +18,7 @@ export const getPaginatedResults = ({
   sortBy,
   sortDirection,
   resultFormat,
-  langTag,
+  dynamicLangTag,
 }) => {
   let q = facetResultSetQuery
   const perspectiveConfig = backendSearchConfig[resultClass]
@@ -26,9 +26,11 @@ export const getPaginatedResults = ({
     endpoint,
     facets,
     facetClass,
+    enableDynamicLanguageChange,
     defaultConstraint = null,
     langTagSecondary = null
   } = perspectiveConfig
+  const langTag = enableDynamicLanguageChange ? dynamicLangTag : perspectiveConfig.langTag || null
   const resultClassConfig = perspectiveConfig.resultClasses[resultClass]
   const {
     propertiesQueryBlock,
@@ -110,7 +112,8 @@ export const getAllResults = ({
   fromID = null,
   toID = null,
   period = null,
-  province = null
+  province = null,
+  dynamicLangTag
 }) => {
   const finalPerspectiveID = perspectiveID || facetClass
   const perspectiveConfig = backendSearchConfig[finalPerspectiveID]
@@ -124,9 +127,10 @@ export const getAllResults = ({
   const {
     endpoint,
     defaultConstraint = null,
-    langTag = null,
-    langTagSecondary = null
+    langTagSecondary = null,
+    enableDynamicLanguageChange
   } = perspectiveConfig
+  const langTag = enableDynamicLanguageChange ? dynamicLangTag : perspectiveConfig.langTag || null
   const resultClassConfig = perspectiveConfig.resultClasses[resultClass]
   if (resultClassConfig === undefined) {
     console.log(`Error: result class "${resultClass}" not defined for perspective "${finalPerspectiveID}"`)
@@ -265,7 +269,8 @@ export const getByURI = ({
   facetClass,
   constraints,
   uri,
-  resultFormat
+  resultFormat,
+  dynamicLangTag
 }) => {
   let perspectiveConfig
   if (perspectiveID) {
@@ -275,9 +280,10 @@ export const getByURI = ({
   }
   const {
     endpoint,
-    langTag = null,
-    langTagSecondary = null
+    langTagSecondary = null,
+    enableDynamicLanguageChange
   } = perspectiveConfig
+  const langTag = enableDynamicLanguageChange ? dynamicLangTag : perspectiveConfig.langTag || null
   const resultClassConfig = perspectiveConfig.resultClasses[resultClass]
   const {
     propertiesQueryBlock,

--- a/src/server/sparql/FacetValues.js
+++ b/src/server/sparql/FacetValues.js
@@ -24,10 +24,12 @@ export const getFacet = async ({
   sortDirection = null,
   constraints,
   resultFormat,
-  constrainSelf
+  constrainSelf,
+  dynamicLangTag
 }) => {
   const facetConfig = backendSearchConfig[facetClass].facets[facetID]
-  const { endpoint, defaultConstraint = null, langTag = null } = backendSearchConfig[facetClass]
+  const { endpoint, defaultConstraint = null, enableDynamicLanguageChange } = backendSearchConfig[facetClass]
+  const langTag = enableDynamicLanguageChange ? dynamicLangTag : backendSearchConfig[facetClass].langTag || null
   // choose query template and result mapper:
   let q = ''
   let mapper = null


### PR DESCRIPTION
What have been done:

- Handling langTag in the `/paginated`, `/all`, `/facet`, and `/page/{uri}` endpoint. We get the language value from the state instead of the perspective configuration. 

How to use:

- In each `perspective.json` file, there is a variable `enableDynamicLanguageChange` used to choose the langTag from the UI selection, or the langTag defined in `perspective.json` file. If `enableDynamicLanguageChange` is set to `true`, then the langTag from the UI selection is enabled, and vice versa. 
- If the language filter is considered, the sparql query need to have the filter query, for example 
```
FILTER(LANG(?keyword__prefLabel) = '<LANG>')
``` 