### PR TITLE
fix: replace selected query block by a bind

### DIFF
--- a/server/src/sparql/FacetValues.js
+++ b/server/src/sparql/FacetValues.js
@@ -203,16 +203,16 @@ const generateSelectedBlock = ({
   currentSelectionsWithoutUnknown,
   literal
 }) => {
-  const selectedFilter = generateSelectedFilter({
-    currentSelectionsWithoutUnknown,
-    inverse: false,
-    literal
-  })
+  const selections = literal
+    ? `'${currentSelectionsWithoutUnknown.join("', '")}'`
+    : `<${currentSelectionsWithoutUnknown.join('>, <')}>`
+  // Mark the selected value(s) with a direct BIND instead of a triple-less
+  // OPTIONAL { FILTER(?id IN ..) BIND(true AS ?selected_) }: that construct is
+  // mistranslated by some engines (QLever silently drops the flag; the VALUES
+  // variant makes Ontop rebind ?id and miscount). ?id is already bound in the
+  // enclosing group, so IN(...) evaluates portably.
   return `
-          OPTIONAL {
-            ${selectedFilter}
-            BIND(true AS ?selected_)
-          }
+          BIND(IF(?id IN ( ${selections} ), true, false) AS ?selected_)
   `
 }
 
@@ -277,16 +277,6 @@ const getUriFilters = (constraints, facetID) => {
   return filters
 }
 
-export const generateSelectedFilter = ({
-  currentSelectionsWithoutUnknown,
-  inverse,
-  literal
-}) => {
-  const selections = literal ? `'${currentSelectionsWithoutUnknown.join("' '")}'` : `<${currentSelectionsWithoutUnknown.join('> <')}>`
-  return (`
-          VALUES ?id { ${selections} }
-  `)
-}
 
 const unknownBlock = `
   UNION


### PR DESCRIPTION
I noticed the change we made from `FILTER IN` to using `VALUES` for the selected filter actually did break ontop engines. Instead of getting all the facet values and setting all the selected ones to have selected true, it collapsed them all into only returning the selected ones. I experimented a bit with different types of queries for both ontop and qlever and came up with this that should work for any sparql engine. It would be great if you could test this works for your qlever endpoints and then merge it.